### PR TITLE
Remove Core Data warnings workaround

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -6,11 +6,6 @@ if arguments.isEmpty {
     exit(EXIT_FAILURE)
 }
 
-// Replace stderr (where NSLog prints to) until http://www.openradar.me/30362625 is fixed
-let devNull = open("/dev/null", O_WRONLY)
-dup2(devNull, 2)
-close(devNull)
-
 guard let addressBook = ABAddressBook.shared() else {
     fputs("Failed to create address book (check your Contacts privacy settings)\n", stderr)
     exit(EXIT_FAILURE)


### PR DESCRIPTION
This seems to have been fixed in High Sierra